### PR TITLE
Configure browser specific npm run commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,122 +1,9 @@
 {
   "name": "janus",
   "version": "1.0.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "janus",
-      "version": "1.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "@adobe/fetch": "^3.1.4",
-        "yaml": "^2.1.1"
-      },
-      "devDependencies": {
-        "@playwright/test": "^1.26.1"
-      }
-    },
-    "node_modules/@adobe/fetch": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-3.1.4.tgz",
-      "integrity": "sha512-cyz2ssrdg14owpE/X90aFfXFv1XUj056A5iw56TV3/yytFzX1p/ef94sGDgZgrsrD6YVCqlPoDYurnNaLNwNeA==",
-      "dependencies": {
-        "debug": "4.3.4",
-        "http-cache-semantics": "4.1.0",
-        "lru-cache": "7.14.0"
-      },
-      "engines": {
-        "node": ">=12.0"
-      }
-    },
-    "node_modules/@playwright/test": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.26.1.tgz",
-      "integrity": "sha512-bNxyZASVt2adSZ9gbD7NCydzcb5JaI0OR9hc7s+nmPeH604gwp0zp17NNpwXY4c8nvuBGQQ9oGDx72LE+cUWvw==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "playwright-core": "1.26.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@types/node": {
-      "version": "18.7.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.23.tgz",
-      "integrity": "sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==",
-      "dev": true
-    },
-    "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
-    },
-    "node_modules/lru-cache": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.0.tgz",
-      "integrity": "sha512-EIRtP1GrSJny0dqb50QXRUNBxHJhcpxHC++M5tD7RYbvLLn5KVWKsbyswSSqDuU15UFi3bgTQIY8nhDMeF6aDQ==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/playwright-core": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.1.tgz",
-      "integrity": "sha512-hzFchhhxnEiPc4qVPs9q2ZR+5eKNifY2hQDHtg1HnTTUuphYCBP8ZRb2si+B1TR7BHirgXaPi48LIye5SgrLAA==",
-      "dev": true,
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/yaml": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
-      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
-      "engines": {
-        "node": ">= 14"
-      }
-    }
-  },
   "dependencies": {
-    "@adobe/fetch": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-3.1.4.tgz",
-      "integrity": "sha512-cyz2ssrdg14owpE/X90aFfXFv1XUj056A5iw56TV3/yytFzX1p/ef94sGDgZgrsrD6YVCqlPoDYurnNaLNwNeA==",
-      "requires": {
-        "debug": "4.3.4",
-        "http-cache-semantics": "4.1.0",
-        "lru-cache": "7.14.0"
-      }
-    },
     "@playwright/test": {
       "version": "1.26.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.26.1.tgz",
@@ -133,39 +20,18 @@
       "integrity": "sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==",
       "dev": true
     },
-    "debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+    "playwright": {
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.26.1.tgz",
+      "integrity": "sha512-WQmEdCgYYe8jOEkhkW9QLcK0PB+w1RZztBLYIT10MEEsENYg251cU0IzebDINreQsUt+HCwwRhtdz4weH9ICcQ==",
       "requires": {
-        "ms": "2.1.2"
+        "playwright-core": "1.26.1"
       }
-    },
-    "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
-    },
-    "lru-cache": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.0.tgz",
-      "integrity": "sha512-EIRtP1GrSJny0dqb50QXRUNBxHJhcpxHC++M5tD7RYbvLLn5KVWKsbyswSSqDuU15UFi3bgTQIY8nhDMeF6aDQ=="
-    },
-    "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "playwright-core": {
       "version": "1.26.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.1.tgz",
-      "integrity": "sha512-hzFchhhxnEiPc4qVPs9q2ZR+5eKNifY2hQDHtg1HnTTUuphYCBP8ZRb2si+B1TR7BHirgXaPi48LIye5SgrLAA==",
-      "dev": true
-    },
-    "yaml": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
-      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw=="
+      "integrity": "sha512-hzFchhhxnEiPc4qVPs9q2ZR+5eKNifY2hQDHtg1HnTTUuphYCBP8ZRb2si+B1TR7BHirgXaPi48LIye5SgrLAA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,14 @@
     "description": "Automate E2E testing of Milo-based projects.",
     "main": "index.js",
     "scripts": {
-        "test": "npx playwright test"
+        "test": "npx playwright test",
+        "test:gui": "npx playwright test --headed",
+        "test:chrome": "playwright test --config=playwright.config.js --project=chromium --headed",
+        "test:firefox": "playwright test --config=playwright.config.js --project=firefox --headed",
+        "test:safari": "playwright test --config=playwright.config.js --project=webkit --headed",
+        "test:chrome-headless": "playwright test --config=playwright.config.js --project=chromium",
+        "test:firefox-headless": "playwright test --config=playwright.config.js --project=firefox",
+        "test:safari-hedless": "playwright test --config=playwright.config.js --project=webkit"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Added support for following npm run commands for tests

- `npm run test:chrome` : Runs all tests on chrome browser in gui mode
- `npm run test:firefox`  : Runs all tests on firefox browser in gui mode
- `npm run test:safari` : Runs all tests on safari browser in gui mode
- `npm run test:chrome-headless` : Runs all tests on chrome browser in headless mode 
- `npm run test:firefox-headless`  :  Runs all tests on firefox browser in headless mode
- `npm run test:safari-headless` : Runs all tests on safari browser in headless mode
- `npm run test:gui` : Runs all tests on all browsers in gui mode

Note : User can add additional tags to above command to choose specific tests.